### PR TITLE
Clarify project summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# York - a fun basic crypto exercise
+# York - a fun basic cryptography exercise
 
 *Written in 2019 by Eliah Kagan \<degeneracypressure@gmail.com\>.*
 

--- a/york.py
+++ b/york.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# york.py - a fun basic crypto exercise
+# york.py - a fun basic cryptography exercise
 #
 # Written in 2019 by Eliah Kagan <degeneracypressure@gmail.com>.
 #


### PR DESCRIPTION
Traditionally "crypto" abbreviates "cryptography" (or sometimes "cryptology" or "cryptanalysis"), but lately it is often used to mean "cryptocurrency." So I've spelled out "cryptography" for clarity.